### PR TITLE
[fix/refactor] 충돌 버그 수정, 트럼펫 공격 완성도 개선, 오브젝트 책임 분리 개선, etc

### DIFF
--- a/Assets/Animator/Supporter/Guitar.overrideController
+++ b/Assets/Animator/Supporter/Guitar.overrideController
@@ -10,4 +10,4 @@ AnimatorOverrideController:
   m_Controller: {fileID: 9100000, guid: b2f90776ba47b0f4c993cc0d9dd2c9f4, type: 2}
   m_Clips:
   - m_OriginalClip: {fileID: 7400000, guid: 935420bb172eae4439a5575495b1dee9, type: 2}
-    m_OverrideClip: {fileID: 7400000, guid: 42bf0ab6df191054bb95bb504ed1ecce, type: 2}
+    m_OverrideClip: {fileID: 7400000, guid: c931605d4acace04f9799d95018ddfe4, type: 2}

--- a/Assets/Anims/Supporter/Guitar.anim.meta
+++ b/Assets/Anims/Supporter/Guitar.anim.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 42bf0ab6df191054bb95bb504ed1ecce
+guid: c931605d4acace04f9799d95018ddfe4
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 7400000

--- a/Assets/Billboard.cs
+++ b/Assets/Billboard.cs
@@ -11,6 +11,6 @@ public class Billboard : MonoBehaviour
 
     private void LateUpdate()
     {
-        transform.LookAt(transform.position + (mainCameraTransform.rotation * Vector3.forward));
+        transform.LookAt(transform.position + mainCameraTransform.rotation * Vector3.forward);
     }
 }

--- a/Assets/Prefabs/Monster/Bird Bullet.prefab
+++ b/Assets/Prefabs/Monster/Bird Bullet.prefab
@@ -152,7 +152,7 @@ SphereCollider:
     serializedVersion: 2
     m_Bits: 8
   m_LayerOverridePriority: 0
-  m_IsTrigger: 0
+  m_IsTrigger: 1
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 3

--- a/Assets/Prefabs/Monster/Bird.prefab
+++ b/Assets/Prefabs/Monster/Bird.prefab
@@ -135,10 +135,9 @@ GameObject:
   - component: {fileID: 4764512884699571658}
   - component: {fileID: 9045662003658631478}
   - component: {fileID: 2549186917689299501}
-  - component: {fileID: 2467508190958046846}
   m_Layer: 3
   m_Name: Capsule
-  m_TagString: Monster
+  m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -234,33 +233,6 @@ CapsuleCollider:
   m_Height: 2
   m_Direction: 1
   m_Center: {x: 0, y: 0, z: 0}
---- !u!54 &2467508190958046846
-Rigidbody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4347066431537712348}
-  serializedVersion: 4
-  m_Mass: 1
-  m_Drag: 0
-  m_AngularDrag: 0.05
-  m_CenterOfMass: {x: 0, y: 0, z: 0}
-  m_InertiaTensor: {x: 1, y: 1, z: 1}
-  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ImplicitCom: 1
-  m_ImplicitTensor: 1
-  m_UseGravity: 1
-  m_IsKinematic: 0
-  m_Interpolate: 0
-  m_Constraints: 0
-  m_CollisionDetection: 0
 --- !u!1 &8862366945470796105
 GameObject:
   m_ObjectHideFlags: 0
@@ -271,8 +243,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1463108897735737651}
   - component: {fileID: 4683626809916441319}
-  - component: {fileID: 4557846582026366611}
-  - component: {fileID: 3027538239232976292}
+  - component: {fileID: 3225711977625943573}
   m_Layer: 3
   m_Name: Bird
   m_TagString: Monster
@@ -318,30 +289,7 @@ MonoBehaviour:
   damageEffect: {fileID: 2978790852640608304, guid: 725e18ceb4b26124f9413f1db4ea60c6, type: 3}
   bulletPref: {fileID: 6795244698053039538, guid: dc5ee04e23dd8be428bc5ab99f9df29c, type: 3}
   bulletSO: {fileID: 11400000, guid: 601b843ff5e3cc54da0425cacd2e0475, type: 2}
---- !u!136 &4557846582026366611
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8862366945470796105}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Radius: 0.5
-  m_Height: 1
-  m_Direction: 1
-  m_Center: {x: 0, y: 0, z: 0}
---- !u!54 &3027538239232976292
+--- !u!54 &3225711977625943573
 Rigidbody:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -364,7 +312,7 @@ Rigidbody:
   m_ImplicitCom: 1
   m_ImplicitTensor: 1
   m_UseGravity: 1
-  m_IsKinematic: 1
+  m_IsKinematic: 0
   m_Interpolate: 0
-  m_Constraints: 0
+  m_Constraints: 112
   m_CollisionDetection: 0

--- a/Assets/Prefabs/Monster/Frog.prefab
+++ b/Assets/Prefabs/Monster/Frog.prefab
@@ -27,8 +27,8 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2419408046695013915}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0.619, z: 0}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.61900043, z: 0}
   m_LocalScale: {x: 0.4, y: 0.4, z: 0.1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -135,10 +135,9 @@ GameObject:
   - component: {fileID: 4764512884699571658}
   - component: {fileID: 9045662003658631478}
   - component: {fileID: 2549186917689299501}
-  - component: {fileID: 2728709149263821543}
   m_Layer: 3
   m_Name: Capsule
-  m_TagString: Monster
+  m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -151,7 +150,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4347066431537712348}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 1, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
@@ -234,33 +233,6 @@ CapsuleCollider:
   m_Height: 2
   m_Direction: 1
   m_Center: {x: 0, y: 0, z: 0}
---- !u!54 &2728709149263821543
-Rigidbody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4347066431537712348}
-  serializedVersion: 4
-  m_Mass: 1
-  m_Drag: 0
-  m_AngularDrag: 0.05
-  m_CenterOfMass: {x: 0, y: 0, z: 0}
-  m_InertiaTensor: {x: 1, y: 1, z: 1}
-  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ImplicitCom: 1
-  m_ImplicitTensor: 1
-  m_UseGravity: 1
-  m_IsKinematic: 0
-  m_Interpolate: 0
-  m_Constraints: 0
-  m_CollisionDetection: 0
 --- !u!1 &8862366945470796105
 GameObject:
   m_ObjectHideFlags: 0
@@ -271,8 +243,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1463108897735737651}
   - component: {fileID: 204769466236804195}
-  - component: {fileID: 4557846582026366611}
-  - component: {fileID: 3027538239232976292}
+  - component: {fileID: 8764256430768160056}
   m_Layer: 3
   m_Name: Frog
   m_TagString: Monster
@@ -316,30 +287,7 @@ MonoBehaviour:
   fixedPosition: {x: 0, y: 0, z: 0}
   poolPrefabRef: {fileID: 0}
   damageEffect: {fileID: 2978790852640608304, guid: 725e18ceb4b26124f9413f1db4ea60c6, type: 3}
---- !u!136 &4557846582026366611
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8862366945470796105}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Radius: 0.5
-  m_Height: 1
-  m_Direction: 1
-  m_Center: {x: 0, y: 0, z: 0}
---- !u!54 &3027538239232976292
+--- !u!54 &8764256430768160056
 Rigidbody:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -362,7 +310,7 @@ Rigidbody:
   m_ImplicitCom: 1
   m_ImplicitTensor: 1
   m_UseGravity: 1
-  m_IsKinematic: 1
+  m_IsKinematic: 0
   m_Interpolate: 0
-  m_Constraints: 0
+  m_Constraints: 112
   m_CollisionDetection: 0

--- a/Assets/Prefabs/Monster/Pig.prefab
+++ b/Assets/Prefabs/Monster/Pig.prefab
@@ -135,10 +135,9 @@ GameObject:
   - component: {fileID: 4764512884699571658}
   - component: {fileID: 9045662003658631478}
   - component: {fileID: 2549186917689299501}
-  - component: {fileID: 8181098119169362873}
   m_Layer: 3
   m_Name: Capsule
-  m_TagString: Monster
+  m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -234,33 +233,6 @@ CapsuleCollider:
   m_Height: 2
   m_Direction: 1
   m_Center: {x: 0, y: 0, z: 0}
---- !u!54 &8181098119169362873
-Rigidbody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4347066431537712348}
-  serializedVersion: 4
-  m_Mass: 1
-  m_Drag: 0
-  m_AngularDrag: 0.05
-  m_CenterOfMass: {x: 0, y: 0, z: 0}
-  m_InertiaTensor: {x: 1, y: 1, z: 1}
-  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ImplicitCom: 1
-  m_ImplicitTensor: 1
-  m_UseGravity: 1
-  m_IsKinematic: 0
-  m_Interpolate: 0
-  m_Constraints: 0
-  m_CollisionDetection: 0
 --- !u!1 &8862366945470796105
 GameObject:
   m_ObjectHideFlags: 0
@@ -271,8 +243,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1463108897735737651}
   - component: {fileID: 204769466236804195}
-  - component: {fileID: 4557846582026366611}
-  - component: {fileID: 7706633419095204254}
+  - component: {fileID: 4451808984218726444}
   m_Layer: 3
   m_Name: Pig
   m_TagString: Monster
@@ -316,30 +287,7 @@ MonoBehaviour:
   fixedPosition: {x: 0, y: 0, z: 0}
   poolPrefabRef: {fileID: 0}
   damageEffect: {fileID: 2978790852640608304, guid: 725e18ceb4b26124f9413f1db4ea60c6, type: 3}
---- !u!136 &4557846582026366611
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8862366945470796105}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Radius: 0.5
-  m_Height: 1
-  m_Direction: 1
-  m_Center: {x: 0, y: 0, z: 0}
---- !u!54 &7706633419095204254
+--- !u!54 &4451808984218726444
 Rigidbody:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -362,7 +310,7 @@ Rigidbody:
   m_ImplicitCom: 1
   m_ImplicitTensor: 1
   m_UseGravity: 1
-  m_IsKinematic: 1
+  m_IsKinematic: 0
   m_Interpolate: 0
-  m_Constraints: 0
+  m_Constraints: 112
   m_CollisionDetection: 0

--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -122,6 +122,7 @@ GameObject:
   - component: {fileID: 3203737756291170368}
   - component: {fileID: 3400730769291665077}
   - component: {fileID: 7904221937565793670}
+  - component: {fileID: 3559614958046845973}
   m_Layer: 6
   m_Name: LowerBody
   m_TagString: Untagged
@@ -240,6 +241,25 @@ MonoBehaviour:
       Data3: 81829001
       Data4: -598778595
     Path: event:/footstep
+--- !u!114 &3559614958046845973
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 268755444838662572}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2780811d77e2c054f98b38cde0f3a7ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  footstepSound:
+    Guid:
+      Data1: 884995931
+      Data2: 1336011141
+      Data3: 81829001
+      Data4: -598778595
+    Path: event:/footstep
 --- !u!1 &1639018925888101073
 GameObject:
   m_ObjectHideFlags: 0
@@ -251,6 +271,7 @@ GameObject:
   - component: {fileID: 1378509667902924742}
   - component: {fileID: 2534513215303206321}
   - component: {fileID: 6669389606085203778}
+  - component: {fileID: 2987180947757309109}
   m_Layer: 6
   m_Name: UpperBody
   m_TagString: Untagged
@@ -350,6 +371,18 @@ Animator:
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorStateOnDisable: 0
   m_WriteDefaultValuesOnDisable: 0
+--- !u!114 &2987180947757309109
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1639018925888101073}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: de3e2d321d5360d43b2bb351c1a030ed, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1967095776610386413
 GameObject:
   m_ObjectHideFlags: 0
@@ -361,7 +394,6 @@ GameObject:
   - component: {fileID: 7787555141881632627}
   - component: {fileID: 6022887412279704646}
   - component: {fileID: 2328924876236304163}
-  - component: {fileID: 795445668615899380}
   - component: {fileID: 3683299040292228609}
   m_Layer: 6
   m_Name: Player
@@ -386,6 +418,7 @@ Transform:
   - {fileID: 5379889901784053234}
   - {fileID: 1378509667902924742}
   - {fileID: 1898834528548932095}
+  - {fileID: 6899076293828972765}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &6022887412279704646
@@ -402,19 +435,20 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   moveSpeed: 3
   maxHealth: 100
-  attackSound:
-    Guid:
-      Data1: 1114968096
-      Data2: 1080289715
-      Data3: -1534067292
-      Data4: 1798681645
-    Path: event:/punchy-acoustic-snare-263511
   shockwavePrefab: {fileID: 4777567964922956666, guid: 28903700e7449494b8947e5ea43b5e86, type: 3}
   attackRange: 5
-  attackCooldown: 0.47
+  attackCooldown: 0.3
   attackDamage: 1
   gold: 0
+  killCount: 0
   noteJudge: {fileID: 0}
+  rideOneShotSound:
+    Guid:
+      Data1: 1670025413
+      Data2: 1323892446
+      Data3: -1745891149
+      Data4: 872864145
+    Path: event:/percurssion_Ride
 --- !u!54 &2328924876236304163
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -442,29 +476,6 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 112
   m_CollisionDetection: 0
---- !u!136 &795445668615899380
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1967095776610386413}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Radius: 0.2
-  m_Height: 1
-  m_Direction: 1
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!212 &3683299040292228609
 SpriteRenderer:
   m_ObjectHideFlags: 0
@@ -520,3 +531,58 @@ SpriteRenderer:
   m_WasSpriteAssigned: 0
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!1 &4434271658642017342
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6899076293828972765}
+  - component: {fileID: 7751711064314379284}
+  m_Layer: 6
+  m_Name: Capsule
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6899076293828972765
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4434271658642017342}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7787555141881632627}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!136 &7751711064314379284
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4434271658642017342}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.2
+  m_Height: 1
+  m_Direction: 1
+  m_Center: {x: 0, y: 0, z: 0}

--- a/Assets/Prefabs/Supporter/Guitar Bullet.prefab
+++ b/Assets/Prefabs/Supporter/Guitar Bullet.prefab
@@ -150,9 +150,9 @@ SphereCollider:
     m_Bits: 0
   m_ExcludeLayers:
     serializedVersion: 2
-    m_Bits: 0
+    m_Bits: 64
   m_LayerOverridePriority: 0
-  m_IsTrigger: 0
+  m_IsTrigger: 1
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 3

--- a/Assets/Prefabs/Supporter/Trumpet.prefab
+++ b/Assets/Prefabs/Supporter/Trumpet.prefab
@@ -9,9 +9,6 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 2273214679919450017}
-  - component: {fileID: 2971586063286335334}
-  - component: {fileID: 838143204194735927}
-  - component: {fileID: 3961051502154629755}
   - component: {fileID: 758823464691577370}
   m_Layer: 0
   m_Name: Trumpet
@@ -32,16 +29,66 @@ Transform:
   m_LocalPosition: {x: 57.3, y: 0.5, z: 22}
   m_LocalScale: {x: 0.075, y: 0.075, z: 0.075}
   m_ConstrainProportionsScale: 1
-  m_Children: []
+  m_Children:
+  - {fileID: 2488354942849782537}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &2971586063286335334
-SpriteRenderer:
+--- !u!114 &758823464691577370
+MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 546918062162575414}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8558e5e12e6ca534ba42957551edf85a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  supporterData: {fileID: 11400000, guid: 5cd7d8e7fa7174d4498565863993fe65, type: 2}
+  poolPrefabRef: {fileID: 0}
+  patternEffect: {fileID: 5148517558999091699, guid: 317f466e125385948b74cf3c41ac803f, type: 3}
+--- !u!1 &4443485696868769753
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2488354942849782537}
+  - component: {fileID: 6971795309257031495}
+  - component: {fileID: 4715586249102767082}
+  - component: {fileID: 7412048993705294904}
+  m_Layer: 0
+  m_Name: Sprite
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2488354942849782537
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4443485696868769753}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2273214679919450017}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &6971795309257031495
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4443485696868769753}
   m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0
@@ -90,14 +137,14 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
---- !u!95 &838143204194735927
+--- !u!95 &4715586249102767082
 Animator:
   serializedVersion: 7
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 546918062162575414}
+  m_GameObject: {fileID: 4443485696868769753}
   m_Enabled: 1
   m_Avatar: {fileID: 0}
   m_Controller: {fileID: 9100000, guid: b2f90776ba47b0f4c993cc0d9dd2c9f4, type: 2}
@@ -112,30 +159,15 @@ Animator:
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorStateOnDisable: 0
   m_WriteDefaultValuesOnDisable: 0
---- !u!114 &3961051502154629755
+--- !u!114 &7412048993705294904
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 546918062162575414}
+  m_GameObject: {fileID: 4443485696868769753}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 8e76d8f75c1cc5c4eb353dae39a10cfe, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &758823464691577370
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 546918062162575414}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8558e5e12e6ca534ba42957551edf85a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  supporterData: {fileID: 11400000, guid: 5cd7d8e7fa7174d4498565863993fe65, type: 2}
-  poolPrefabRef: {fileID: 0}
-  patternEffect: {fileID: 5148517558999091699, guid: 317f466e125385948b74cf3c41ac803f, type: 3}

--- a/Assets/Scripts/02. Player/00. Shockwave/Shockwave.cs
+++ b/Assets/Scripts/02. Player/00. Shockwave/Shockwave.cs
@@ -107,7 +107,7 @@ public class Shockwave : MonoBehaviour
         if (((1 << other.gameObject.layer) & enemyLayer.value) != 0)
         {
             Debug.Log("sw Enemy Detected");
-            Monster monster = other.GetComponent<Monster>();
+            Monster monster = other.GetComponentInParent<Monster>();
             if (monster != null)
             {
                 int monsterId = monster.GetInstanceID();

--- a/Assets/Scripts/02. Player/PlayerController.cs
+++ b/Assets/Scripts/02. Player/PlayerController.cs
@@ -295,7 +295,7 @@ public class PlayerController : MonoBehaviour
     {
         if (other.gameObject.layer == LayerMask.NameToLayer("Enemy"))
         {
-            Monster monster = other.GetComponent<Monster>();
+            Monster monster = other.GetComponentInParent<Monster>();
             if (monster != null && !monstersInRange.Contains(monster))
             {
                 monstersInRange.Add(monster);
@@ -308,7 +308,7 @@ public class PlayerController : MonoBehaviour
     {
         if (other.gameObject.layer == LayerMask.NameToLayer("Enemy"))
         {
-            Monster monster = other.GetComponent<Monster>();
+            Monster monster = other.GetComponentInParent<Monster>();
             if (monster != null)
             {
                 monstersInRange.Remove(monster);

--- a/Assets/Scripts/03. Monster/01. RangedMonster/Bullet.cs
+++ b/Assets/Scripts/03. Monster/01. RangedMonster/Bullet.cs
@@ -1,3 +1,4 @@
+using Unity.VisualScripting;
 using UnityEngine;
 
 public class Bullet : MonoBehaviour
@@ -12,41 +13,49 @@ public class Bullet : MonoBehaviour
     public bool IsPenetrable { get; set; }      // 관통 가능 여부
     public EFriendly Friendly { get; set; }
 
+    // 레이어 인덱스 캐싱
+    private int playerLayer;
+    private int enemyLayer;
+
+    private void Awake()
+    {
+        playerLayer = LayerMask.NameToLayer("Player");
+        enemyLayer = LayerMask.NameToLayer("Enemy");
+    }
+
     private void FixedUpdate()
     {
         transform.position += Direction * BulletSpeed * Time.deltaTime;
     }
 
-    private void OnCollisionEnter(Collision collision)
+    private void OnTriggerEnter(Collider other)
     {
-        if (!collision.gameObject.CompareTag("Player") && Friendly == EFriendly.Monster)
-        {
-            return;
-        }
-        if (!collision.gameObject.CompareTag("Monster") && Friendly == EFriendly.Player)
-        {
-            return;
-        }
+        bool hitHostileObject = false;
 
-        if (Friendly == EFriendly.Monster)
+        // 플레이어 공격
+        if (other.gameObject.layer == playerLayer && other.name == "Capsule" && Friendly == EFriendly.Monster)
         {
-            PlayerController playerController = collision.gameObject.GetComponent<PlayerController>();
+            PlayerController playerController = other.gameObject.GetComponentInParent<PlayerController>();
             if (playerController != null)
             {
                 playerController.TakeDamage(Damage); // 플레이어 체력 감소
-            }
-        }
-        if (Friendly == EFriendly.Player)
-        {
-            Debug.Log("test");
-            Monster monsterComp = collision.gameObject.GetComponentInParent<Monster>();
-            if (monsterComp != null)
-            {
-                monsterComp.TakeDamage(Damage);
+                hitHostileObject = true;
             }
         }
 
-        if (!IsPenetrable)
+        // 적 공격
+        else if (other.gameObject.layer == enemyLayer && Friendly == EFriendly.Player)
+        {
+            Monster monsterComp = other.gameObject.GetComponentInParent<Monster>();
+            if (monsterComp != null)
+            {
+                monsterComp.TakeDamage(Damage);
+                hitHostileObject = true;
+            }
+        }
+
+        // 비관통 탄환은 풀로 반환
+        if (hitHostileObject && !IsPenetrable)
         {
             PoolManager.Instance.Return(PoolPrefRef, gameObject); // 풀로 반환
         }

--- a/Assets/Scripts/03. Monster/IMonsterPattern.cs
+++ b/Assets/Scripts/03. Monster/IMonsterPattern.cs
@@ -39,13 +39,13 @@ public class RangedPattern : IMonsterPattern
 
         newBullet.SetActive(false);                                     // 잠시 비활성화
 
-        newBullet.transform.position = transform.position;              // 위치 설정
-        Bullet bulletComp = newBullet.GetComponent<Bullet>();           // 컴포넌트 가져오기
-        bulletComp.PoolPrefRef = bulletPref;                            // 풀 반환용 프리팹 Set
-        bulletComp.BulletSpeed = bulletSO.bulletSpeed;                  // 탄속 Set
-        bulletComp.Damage = bulletSO.bulletDamage;                      // 공격력 Set
+        newBullet.transform.position = transform.position + new Vector3(0f, 0.5f, 0f);  // 위치 설정
+        Bullet bulletComp = newBullet.GetComponent<Bullet>();                           // 컴포넌트 가져오기
+        bulletComp.PoolPrefRef = bulletPref;                                            // 풀 반환용 프리팹 Set
+        bulletComp.BulletSpeed = bulletSO.bulletSpeed;                                  // 탄속 Set
+        bulletComp.Damage = bulletSO.bulletDamage;                                      // 공격력 Set
         Vector3 direction = player.position - newBullet.transform.position;
-        bulletComp.Direction = new Vector3(direction.x, 0f, direction.z); // 방향 Set
+        bulletComp.Direction = new Vector3(direction.x, 0f, direction.z);               // 방향 Set
         bulletComp.Direction = bulletComp.Direction.normalized;
         bulletComp.IsPenetrable = false;
         bulletComp.Friendly = Bullet.EFriendly.Monster;

--- a/Assets/Scripts/04. Supporter/00. Trumpet/Trumpet.cs
+++ b/Assets/Scripts/04. Supporter/00. Trumpet/Trumpet.cs
@@ -3,6 +3,10 @@ using UnityEngine;
 
 public class Trumpet : Supporter
 {
+    private float attackRange = 5f; 
+    private float angleRange = 90f; 
+    private Color gizmoColor = Color.red;
+
     protected override void Start()
     {
         base.Start();
@@ -15,9 +19,40 @@ public class Trumpet : Supporter
     }
 
     // 트럼펫 범위 보기 테스트
-    //private void OnDrawGizmos()
-    //{
-    //   Handles.DrawSolidArc(transform.position, Vector3.up, transform.forward, 45f, 3f);
-    //   Handles.DrawSolidArc(transform.position, Vector3.up, transform.forward, -45f, 3f);
-    //}
+    private void OnDrawGizmos()
+    {
+        Gizmos.color = gizmoColor;
+        Vector3 origin = transform.position;
+
+        // **여기서도 평평한 '앞' 방향을 계산합니다.**
+        Vector3 flatForwardDirection = transform.forward;
+        flatForwardDirection.y = 0; // Y축 값을 0으로 만들어 평평하게 만듭니다.
+        if (flatForwardDirection == Vector3.zero) // 완전히 수직으로 서서 forward가 (0,1,0)이 되는 경우 방지
+        {
+            flatForwardDirection = Vector3.forward; // 기본값 설정 또는 다른 예외 처리
+        }
+        flatForwardDirection.Normalize(); 
+
+        // 부채꼴의 양쪽 끝 방향 벡터 계산
+        // Y축을 기준으로 회전하도록 오일러 각도 사용
+        Vector3 rightDir = Quaternion.Euler(0, angleRange / 2f, 0) * flatForwardDirection; 
+        Vector3 leftDir = Quaternion.Euler(0, -angleRange / 2f, 0) * flatForwardDirection; 
+        
+        Gizmos.DrawRay(origin, rightDir * attackRange);
+        Gizmos.DrawRay(origin, leftDir * attackRange);
+
+        // 부채꼴의 호(arc) 그리기
+        int segments = 20; 
+        Vector3 previousPoint = origin + rightDir * attackRange;
+        for (int i = 0; i <= segments; i++)
+        {
+            // 각도를 기준으로 회전시킬 때도 flatForwardDirection을 사용합니다.
+            float currentAngle = angleRange / 2f - (angleRange / segments) * i; 
+            Vector3 currentDir = Quaternion.Euler(0, currentAngle, 0) * flatForwardDirection; 
+            
+            Vector3 currentPoint = origin + currentDir * attackRange;
+            Gizmos.DrawLine(previousPoint, currentPoint);
+            previousPoint = currentPoint;
+        }
+    }
 }

--- a/Assets/Scripts/04. Supporter/ISupporterPattern.cs
+++ b/Assets/Scripts/04. Supporter/ISupporterPattern.cs
@@ -1,3 +1,4 @@
+using System;
 using NUnit.Framework;
 using UnityEngine;
 
@@ -10,23 +11,37 @@ public class TrumpetPattern : ISupporterPattern
 {
     public void ActPattern(Transform transform, Transform player, SupporterSO supporterData)
     {
-        GameObject[] activatingMonsters = GameObject.FindGameObjectsWithTag("Monster");
-        float angleRange = 90f;     // ���հ�
+        // 공격 범위 내 콜라이더 가져오기
+        Collider[] hitColliders = Physics.OverlapSphere(transform.position, supporterData.attackRange);
+        float angleRange = 90f; // 부채꼴 각
 
-        foreach (GameObject monster in activatingMonsters)
+        Vector3 flatForwardDirection = transform.forward;
+        flatForwardDirection.y = 0f;
+        flatForwardDirection.Normalize();
+
+        foreach (Collider hitCollider in hitColliders)
         {
-            Vector3 interV = monster.transform.position - transform.position;
-
-            if (interV.magnitude <= supporterData.attackRange)
+            if (hitCollider.gameObject.layer != LayerMask.NameToLayer("Enemy"))
             {
-                float dot = Vector2.Dot(interV.normalized, transform.forward);
-                float theta = Mathf.Acos(dot);
-                float degree = Mathf.Rad2Deg * theta;
+                continue;
+            }
 
-                if (degree <= angleRange / 2f)
-                {
-                    monster.GetComponent<Monster>().TakeDamage(supporterData.attackDamage);
-                }
+            Monster monsterComp = hitCollider.GetComponentInParent<Monster>();
+            if (monsterComp == null)
+            {
+                continue;
+            }
+
+            Vector3 directionToMonster = (monsterComp.transform.position - transform.position);
+            directionToMonster.y = 0f;
+            directionToMonster.Normalize();
+
+            // 부채꼴 내에 존재하는지 확인
+            float dotProdict = Vector3.Dot(flatForwardDirection, directionToMonster);
+
+            if (dotProdict >= Mathf.Cos(angleRange / 2f * Mathf.Deg2Rad))
+            {
+                monsterComp.TakeDamage(supporterData.attackDamage);
             }
         }
     }


### PR DESCRIPTION
## !!!Player 프리팹 최신화 되었으니 메인 씬에 반영되었는지 머지 후 확인 필요합니다!!!
### 내용
1. 트럼펫 공격 시 Null 에러 발생하는 현상 해결
2. 플레이어, 적 등 오브젝트의 하위에 오브젝트를 만들고, 책임을 각각 분리헤서 할당
    - 콜라이더, 스프라이트 등
3. 테스트를 계속 해보니 트럼펫 공격이 약간 이상하게 나가서 올바르게 나가도록 개선
4. 플레이어의 콜라이더를 하위로 분리함에 따라 Shockwave.cs, PlayerController.cs 코드 일부분을 수정함